### PR TITLE
Added CLI version of z_int calculator.

### DIFF
--- a/z_int_cli/Cargo.toml
+++ b/z_int_cli/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "z_int_calc"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+statrs = "0.16.0"

--- a/z_int_cli/src/main.rs
+++ b/z_int_cli/src/main.rs
@@ -1,0 +1,44 @@
+#[allow(unused_assignments)]
+#[allow(unused_variables)]
+use statrs::distribution::{Normal, ContinuousCDF};
+use std::env;
+mod matches;
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+
+    if args.iter().any(|s: &String| s == "--help")  {
+        println!( "\n\tUse command with arguments in order of alpha mu sigma sample_size\n" );
+        std::process::exit(0x0100);
+    } else if args.len() != 5  {
+        println!( "\nArguments must be passed in this order: \n \t alpha mu sigma sample_size");
+        println!( "\tUse the --help tag for instructions.\n");
+        std::process::exit(0x0100);
+    }
+
+    let alpha_string = &args[1];
+    let alpha: f64 = matches::alpha(alpha_string);
+
+    let mean_string = &args[2];
+    let sample_mean: f64 = matches::float(mean_string);
+
+    let variance_string = &args[3];
+    let variance: f64 = matches::float(variance_string);
+
+
+    let size_string = &args[4];
+    let sample_size: i64 = matches::int(size_string);
+
+    let distribution = Normal::new(0.0, 1.0).unwrap();
+    let z_score: f64 = distribution.inverse_cdf( alpha / 2.0 ).abs();
+
+    let boundary: f64 = z_score * variance.sqrt() / ( sample_size as f64 ).sqrt();
+
+    let min: f64 = sample_mean - boundary;
+    let max: f64 = sample_mean + boundary;
+    
+    let confidence: f64 = (1.0 - alpha) * 100.0;
+    println!( "\n Found {confidence:.2}% confidence interval of {{{min:.3},{max:.3}}}");
+
+}
+

--- a/z_int_cli/src/matches.rs
+++ b/z_int_cli/src/matches.rs
@@ -1,0 +1,31 @@
+
+pub fn alpha(string_in: &String) -> f64 {
+
+    match string_in.trim().parse::<f64>() {
+        Ok( f ) => {
+            match ( f > 0.0 ) && ( f < 1.0 ) {
+                true => f,
+                false => panic!("Warning! Float value must be in [0,1]\n")
+            }
+        }, 
+        Err(..) => panic!( "The input '{}' could not be made into a float.\n", string_in )
+    }
+}
+
+
+pub fn float(string_in: &String) -> f64 {
+
+    match string_in.trim().parse::<f64>() {
+        Ok( f ) => f, 
+        Err(..) => panic!( "The input '{}' could not be made into a float.\n", string_in )
+    }
+}
+
+
+pub fn int(string_in: &String) -> i64 {
+
+    match string_in.trim().parse::<i64>() {
+        Ok( i ) => i, 
+        Err(..) => panic!( "The input '{}' could not be made into an integer.\n", string_in )
+    }
+}


### PR DESCRIPTION
Now available is a z_int_calc command that, when built, can be called via CLI with help tag that shows order in which arguments are provided. Graceful exit and explanation upon misuse.
